### PR TITLE
Update playbooks.json - add correct pluggable enrichment tags to pbs

### DIFF
--- a/fortinet-fortisandbox/playbooks/playbooks.json
+++ b/fortinet-fortisandbox/playbooks/playbooks.json
@@ -578,6 +578,7 @@
           "importedBy": [],
           "recordTags": [
             "Enrichment",
+            "URL_Enrichment",
             "ManualTrigger"
           ]
         },
@@ -1933,6 +1934,7 @@
           "importedBy": [],
           "recordTags": [
             "Enrichment",
+            "File_Enrichment",
             "ManualTrigger"
           ]
         },


### PR DESCRIPTION
#### Descriptions:
SOAR Framework Solution Pack requires playbooks to have a tag in format <indicator_type>_Enrichment - i.e. URL_Enrichment.
Fortinet FortiSandbox is considered a pluggable enrichment integration, but does not work unless the enrichment playbooks have the appropriate tags. This PR is to add correct pluggable enrichment tags to URL and File enrichment sample playbooks

