### PR TITLE
Bug Fixes

### DIFF
--- a/fortinet-fortisandbox/info.json
+++ b/fortinet-fortisandbox/info.json
@@ -838,6 +838,9 @@
           "thumbnail": "",
           "uploadDate": ""
         },
+        "cVEs": [],
+        "workspaces": [],
+        "vulnerabilities": [],
         "name": "",
         "type": "",
         "uuid": "",
@@ -1235,20 +1238,93 @@
           }
         }
       ],
-      "output_schema": {
-        "id": "",
-        "ver": "",
-        "result": {
-          "data": {
-            "msg": ""
-          },
-          "status": {
-            "code": "",
-            "message": ""
-          },
-          "url": ""
+      "conditional_output_schema": [
+        {
+          "condition": "{{ action == \"DOWNLOAD\" }}",
+          "output_schema": {
+            "id": "",
+            "@id": "",
+            "file": {
+              "id": "",
+              "@id": "",
+              "size": "",
+              "uuid": "",
+              "@type": "",
+              "assignee": "",
+              "filename": "",
+              "metadata": [],
+              "mimeType": "",
+              "thumbnail": "",
+              "uploadDate": ""
+            },
+            "name": "",
+            "type": "",
+            "uuid": "",
+            "@type": "",
+            "tasks": [],
+            "alerts": [],
+            "assets": [],
+            "owners": [],
+            "people": [],
+            "@context": "",
+            "assignee": "",
+            "comments": [],
+            "warrooms": [],
+            "incidents": [],
+            "createDate": "",
+            "createUser": {
+              "id": "",
+              "@id": "",
+              "name": "",
+              "uuid": "",
+              "@type": "",
+              "avatar": "",
+              "userId": "",
+              "userType": "",
+              "createDate": "",
+              "createUser": "",
+              "modifyDate": "",
+              "modifyUser": ""
+            },
+            "indicators": [],
+            "modifyDate": "",
+            "modifyUser": {
+              "id": "",
+              "@id": "",
+              "name": "",
+              "uuid": "",
+              "@type": "",
+              "avatar": "",
+              "userId": "",
+              "userType": "",
+              "createDate": "",
+              "createUser": "",
+              "modifyDate": "",
+              "modifyUser": ""
+            },
+            "recordTags": [],
+            "userOwners": [],
+            "description": ""
+          }
+        },
+        {
+          "condition": "{{ action != \"DOWNLOAD\" }}",
+          "output_schema": {
+            "id": "",
+            "ver": "",
+            "result": {
+              "data": {
+                "msg": ""
+              },
+              "status": {
+                "code": "",
+                "message": ""
+              },
+              "url": ""
+            }
+          }
         }
-      },
+      ],
       "enabled": true
     }
   ]

--- a/fortinet-fortisandbox/info.json
+++ b/fortinet-fortisandbox/info.json
@@ -1207,6 +1207,41 @@
                 "editable": true,
                 "visible": true,
                 "value": ""
+              },
+              {
+                "title": "Status",
+                "name": "status",
+                "description": "Select the status of the indicator that you want to add to the allow or block list in Fortinet FortiSandbox. By default it is set to Enabled. You can select from the following options: Enabled or Disabled.",
+                "tooltip": "Select the status of the indicator that you want to add to the allow or block list in Fortinet FortiSandbox. By default it is set to Enabled.",
+                "type": "select",
+                "options": [
+                  "Enabled",
+                  "Disabled"
+                ],
+                "required": false,
+                "editable": true,
+                "visible": true,
+                "value": "Enabled"
+              },
+              {
+                "title": "Expiry Date",
+                "name": "expiry_date",
+                "description": "Specify the expiry datetime for the indicator that you want to add to the allow or block list in Fortinet FortiSandbox.",
+                "tooltip": "Specify the expiry datetime for the indicator that you want to add to the allow or block list in Fortinet FortiSandbox.",
+                "type": "datetime",
+                "required": false,
+                "editable": true,
+                "visible": true
+              },
+              {
+                "title": "Comment",
+                "name": "comment",
+                "description": "Specify the comment for the indicator that you want to add to the allow or block list in Fortinet FortiSandbox.",
+                "tooltip": "Specify the comment for the indicator that you want to add to the allow or block list in Fortinet FortiSandbox.",
+                "type": "text",
+                "required": false,
+                "editable": true,
+                "visible": true
               }
             ],
             "REPLACE": [
@@ -1220,6 +1255,41 @@
                 "editable": true,
                 "visible": true,
                 "value": ""
+              },
+              {
+                "title": "Status",
+                "name": "status",
+                "description": "Select the status of the indicator that you want to replace to the allow or block list in Fortinet FortiSandbox. By default it is set to Enabled. You can select from the following options: Enabled or Disabled.",
+                "tooltip": "Select the status of the indicator that you want to add to the replace or block list in Fortinet FortiSandbox. By default it is set to Enabled.",
+                "type": "select",
+                "options": [
+                  "Enabled",
+                  "Disabled"
+                ],
+                "required": false,
+                "editable": true,
+                "visible": true,
+                "value": "Enabled"
+              },
+              {
+                "title": "Expiry Date",
+                "name": "expiry_date",
+                "description": "Specify the expiry datetime for the indicator that you want to replace to the allow or block list in Fortinet FortiSandbox.",
+                "tooltip": "Specify the expiry datetime for the indicator that you want to replace to the allow or block list in Fortinet FortiSandbox.",
+                "type": "datetime",
+                "required": false,
+                "editable": true,
+                "visible": true
+              },
+              {
+                "title": "Comment",
+                "name": "comment",
+                "description": "Specify the comment for the indicator that you want to replace to the allow or block list in Fortinet FortiSandbox.",
+                "tooltip": "Specify the comment for the indicator that you want to replace to the allow or block list in Fortinet FortiSandbox.",
+                "type": "text",
+                "required": false,
+                "editable": true,
+                "visible": true
               }
             ],
             "DELETE": [

--- a/fortinet-fortisandbox/operations.py
+++ b/fortinet-fortisandbox/operations.py
@@ -295,7 +295,7 @@ def handle_allow_block_list(config, params):
             indicator_type = 'url_regex'
 
         if not indicator_value:
-            indicator_value = ['test']
+            indicator_value = []
 
         indicator_value = indicator_value if isinstance(indicator_value, list) else [indicator_value]
 
@@ -311,8 +311,8 @@ def handle_allow_block_list(config, params):
         if params['action'].lower() == 'download':
             if not response['result']['status']['message'] == 'OK':
                 return response
-            download_file = response['result']['data']['download_file']
-            if download_file:
+            download_file = response['result']['data'].get('download_file', '')
+            if params['action'] == 'DOWNLOAD':
                 filename = '{0}_{1}.txt'.format(params['list_type'].lower(), params['indicator_type'].lower())
                 attachment_name = 'FortiSandbox: Download {0} {1}'.format(params['list_type'], params['indicator_type'])
                 return create_cyops_attachment(base64.b64decode(download_file.encode('utf-8')), attachment_name,

--- a/fortinet-fortisandbox/operations.py
+++ b/fortinet-fortisandbox/operations.py
@@ -8,6 +8,7 @@ Copyright end
 
 import time, os
 import base64
+from datetime import datetime
 from base64 import b64encode
 from integrations.crudhub import make_request, make_file_upload_request
 from connectors.cyops_utilities.builtins import download_file_from_cyops
@@ -298,6 +299,15 @@ def handle_allow_block_list(config, params):
             indicator_value = []
 
         indicator_value = indicator_value if isinstance(indicator_value, list) else [indicator_value]
+        status = params.get('status')
+        expiry_date = params.get('expiry_date')
+        if expiry_date:
+            expiry_date = int(datetime.strptime(expiry_date, "%Y-%m-%dT%H:%M:%S.%fZ").timestamp())
+        comment = params.get('comment', '')
+
+        if status or expiry_date or comment not in (None, ''):
+            for i in range(len(indicator_value)):
+                indicator_value[i] = f"{indicator_value[i]}, {comment}, {expiry_date}, {0 if status == 'Disabled' else 1}"
 
         indicator_value = '\n'.join(indicator_value)
 


### PR DESCRIPTION
#### Change:
- Updated output schema of `Get PDF Report` and `Update Allow or Block List` actions.
- Updated response of `Update Allow or Block List` action if `Action` parameter is selected as `DOWNLOAD` and file is empty.
- Added `Status`, `Expiry Date` and `Comment` parameters to `Update Allow or Block List` action.

#### Fix:
- 1003233: Output schema mismatch for `Get PDF Report` and `Update Allow or Block List`  actions.
- 1003740: Adding new item to Allowlist or Blocklist has parameter Expiry date, comments and status

#### UTCs:
- [x] Tested and verified `Get PDF Report` and `Update Allow or Block List` actions.
- [x] Tested and verified `Update Allow or Block List` action.

